### PR TITLE
Added my_workschedules

### DIFF
--- a/ninetofiver/filters.py
+++ b/ninetofiver/filters.py
@@ -477,7 +477,7 @@ class PerformanceFilter(FilterSet):
 
 
 class ActivityPerformanceFilter(PerformanceFilter):
-    order_fields = PerformanceFilter.order_fields + ('duration', 'description')
+    order_fields = PerformanceFilter.order_fields + ('duration', 'description', 'contract')
     order_by = NullLastOrderingFilter(fields=order_fields)
 
     class Meta(PerformanceFilter.Meta):
@@ -485,6 +485,7 @@ class ActivityPerformanceFilter(PerformanceFilter):
         fields = merge_dicts(PerformanceFilter.Meta.fields, {
             'duration': ['exact', 'gt', 'gte', 'lt', 'lte'],
             'description': ['exact', 'contains', 'icontains'],
+            'contract': ['exact'],
         })
 
 

--- a/ninetofiver/models.py
+++ b/ninetofiver/models.py
@@ -214,7 +214,7 @@ class EmploymentContract(BaseModel):
     user = models.ForeignKey(auth_models.User, on_delete=models.PROTECT)
     company = models.ForeignKey(Company, on_delete=models.PROTECT, limit_choices_to=company_choices)
     employment_contract_type = models.ForeignKey(EmploymentContractType, on_delete=models.PROTECT)
-    work_schedule = models.ForeignKey(WorkSchedule, on_delete=models.PROTECT)
+    work_schedule = models.ForeignKey(WorkSchedule, on_delete=models.CASCADE)
     started_at = models.DateField()
     ended_at = models.DateField(blank=True, null=True)
 

--- a/ninetofiver/serializers.py
+++ b/ninetofiver/serializers.py
@@ -319,3 +319,8 @@ class MyAttachmentSerializer(AttachmentSerializer):
     def create(self, validated_data):
         validated_data['user'] = self.context['request'].user
         return super().create(validated_data)
+
+
+class MyWorkScheduleSerializer(WorkScheduleSerializer):
+    class Meta(WorkScheduleSerializer.Meta):
+        read_only_fields = WorkScheduleSerializer.Meta.read_only_fields + ('user',)

--- a/ninetofiver/tests.py
+++ b/ninetofiver/tests.py
@@ -778,20 +778,38 @@ class MyLeaveRequestsServiceAPITestcase(APITestCase):
 
         url = reverse('my_leave_request_service')
 
-        postResponse = self.client.post(url, create_data, format='json')
-        self.assertEqual(postResponse.status_code, status.HTTP_201_CREATED)
+        # Check for normal creation success
+        post_response = self.client.post(url, create_data, format='json')
+        self.assertEqual(post_response.status_code, status.HTTP_201_CREATED)
 
-        postDuplicateLeaveResponse = self.client.post(url, update_data, format='json')
-        self.assertEqual(postDuplicateLeaveResponse.status_code, status.HTTP_400_BAD_REQUEST)
+        # Check for duplicate creation error
+        post_duplicate_leave_response = self.client.post(url, update_data, format='json')
+        self.assertEqual(post_duplicate_leave_response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        patchResponse = self.client.patch(url, update_data, format='json')
-        self.assertEqual(patchResponse.status_code, status.HTTP_201_CREATED)
+        # Check for update success
+        patch_response = self.client.patch(url, update_data, format='json')
+        self.assertEqual(patch_response.status_code, status.HTTP_201_CREATED)
 
+        # Check for update error
         update_data['leave'] = 99999999
 
-        patchDuplicateDateResponse = self.client.patch(url, update_data, format='json')
-        self.assertEqual(patchDuplicateDateResponse.status_code, status.HTTP_400_BAD_REQUEST)
+        patch_duplicate_date_response = self.client.patch(url, update_data, format='json')
+        self.assertEqual(patch_duplicate_date_response.status_code, status.HTTP_400_BAD_REQUEST)
 
+        # Check for validationerror
+        invalid_leave = factories.LeaveFactory.create(
+            user = user,
+            leave_type = factories.LeaveTypeFactory.create()
+        )
+        invalid_data = {
+            'leave': invalid_leave.id,
+            'timesheet': timesheet.id,
+            'starts_at': datetime.datetime(now.year, now.month, 17, 23, 23, 23),
+            'ends_at': datetime.datetime(now.year, now.month, 14, 5, 5, 5)
+        }
+
+        post_invalid_date_response = self.client.post(url, invalid_data, format='json')
+        self.assertEqual(post_invalid_date_response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class MyTimesheetAPITestCase(testcases.ReadWriteRESTAPITestCaseMixin, testcases.BaseRESTAPITestCase, ModelTestMixin):

--- a/ninetofiver/tests.py
+++ b/ninetofiver/tests.py
@@ -870,8 +870,8 @@ class MyContractDurationAPITestCase(testcases.ReadRESTAPITestCaseMixin, testcase
         )
         self.performance_type = factories.PerformanceTypeFactory.create()
         self.contract = factories.ContractFactory.create(
-            company=factories.InternalCompanyFactory.create(),
-            customer=factories.CompanyFactory.create()
+            company=self.company,
+            customer=self.customer
         )
         super().setUp()
 
@@ -1007,3 +1007,47 @@ class MyAttachmentAPITestCase(testcases.ReadWriteRESTAPITestCaseMixin, testcases
 
     def get_update_response(self, data=None, results=None, use_patch=None, **kwargs):
         return super().get_update_response(data=data, results=results, use_patch=True, format='multipart', **kwargs)
+
+
+class MyWorkScheduleAPITestCase(testcases.ReadWriteRESTAPITestCaseMixin, testcases.BaseRESTAPITestCase, ModelTestMixin):
+    base_name = 'myworkschedule'
+    factory_class = factories.WorkScheduleFactory
+    user_factory = factories.AdminFactory
+    create_data = {
+        'label': 'Test schedule #1',
+        'monday': Decimal('1.20'),
+        'tuesday': Decimal('1.50'),
+        'wednesday': Decimal('1.75'),
+        'thursday': Decimal('0'),
+        'friday': Decimal('2'),
+        'saturday': Decimal('0'),
+        'sunday': Decimal('0'),
+    }
+    update_data = {
+        'label': 'Test schedule #2',
+        'monday': Decimal('2.10'),
+        'tuesday': Decimal('5.10'),
+        'wednesday': Decimal('7.50'),
+        'thursday': Decimal('0'),
+        'friday': Decimal('4'),
+        'saturday': Decimal('0'),
+        'sunday': Decimal('3'),
+    }
+
+    def setUp(self):
+        self.user = factories.AdminFactory.create()
+        self.client.force_authenticate(self.user)
+
+        self.work_schedule = factories.WorkScheduleFactory.create()
+
+        super().setUp()
+
+    def get_object(self, factory):
+        work_schedule = self.work_schedule
+        factories.EmploymentContractFactory.create(
+            user=self.user, 
+            company=factories.CompanyFactory.create(),
+            work_schedule=self.work_schedule,
+            employment_contract_type=factories.EmploymentContractTypeFactory.create()
+        )
+        return work_schedule

--- a/ninetofiver/tests.py
+++ b/ninetofiver/tests.py
@@ -765,14 +765,14 @@ class MyLeaveRequestsServiceAPITestcase(APITestCase):
         create_data = {
             'leave': leave.id,
             'timesheet': timesheet.id,
-            'starts_at': datetime.datetime(now.year, now.month, 12, 7, 34, 34),
-            'ends_at': datetime.datetime(now.year, now.month, 14, 8, 34, 34)
+            'starts_at': datetime.datetime(now.year, 4, 28, 0, 0, 0),
+            'ends_at': datetime.datetime(now.year, 4, 30, 0, 0, 0)
         }
 
         update_data = {
             'leave': leave.id,
             'timesheet': timesheet.id,
-            'starts_at': datetime.datetime(now.year, now.month, 10, 7, 34, 34),
+            'starts_at': datetime.datetime(now.year, now.month, 16, 7, 34, 34),
             'ends_at': datetime.datetime(now.year, now.month, 16, 8, 34, 34)
         }
 
@@ -787,11 +787,7 @@ class MyLeaveRequestsServiceAPITestcase(APITestCase):
         patchResponse = self.client.patch(url, update_data, format='json')
         self.assertEqual(patchResponse.status_code, status.HTTP_201_CREATED)
 
-        newLeave = factories.LeaveFactory.create(
-            user = user,
-            leave_type = factories.LeaveTypeFactory.create() 
-        )
-        update_data['leave'] = newLeave.id
+        update_data['leave'] = 99999999
 
         patchDuplicateDateResponse = self.client.patch(url, update_data, format='json')
         self.assertEqual(patchDuplicateDateResponse.status_code, status.HTTP_400_BAD_REQUEST)

--- a/ninetofiver/tests.py
+++ b/ninetofiver/tests.py
@@ -6,7 +6,7 @@ from django.utils.timezone import utc
 from ninetofiver import factories
 from decimal import Decimal
 from datetime import timedelta
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, ObjectDoesNotExist
 
 import tempfile
 import datetime
@@ -787,6 +787,21 @@ class MyLeaveRequestsServiceAPITestcase(APITestCase):
         post_duplicate_leave_response = self.client.post(url, update_data, format='json')
         self.assertEqual(post_duplicate_leave_response.status_code, status.HTTP_400_BAD_REQUEST)
 
+        #Check for overlapping leavedates
+        overlap_leave = factories.LeaveFactory.create(
+            user = user,
+            leave_type = factories.LeaveTypeFactory.create()
+        )
+        overlap_data = {
+            'leave': overlap_leave.id,
+            'timesheet': timesheet.id,
+            'starts_at': create_data['starts_at'],
+            'ends_at': create_data['ends_at']
+        }
+        post_overlapping_leave_response = self.client.post(url, overlap_data, format='json')
+        self.assertRaises(ValidationError)
+        self.assertEqual(post_overlapping_leave_response.status_code, status.HTTP_400_BAD_REQUEST)
+
         # Check for update success
         patch_response = self.client.patch(url, update_data, format='json')
         self.assertEqual(patch_response.status_code, status.HTTP_201_CREATED)
@@ -799,6 +814,7 @@ class MyLeaveRequestsServiceAPITestcase(APITestCase):
         update_data['leave'] = new_leave.id
 
         patch_duplicate_date_response = self.client.patch(url, update_data, format='json')
+        self.assertRaises(ObjectDoesNotExist)
         self.assertEqual(patch_duplicate_date_response.status_code, status.HTTP_400_BAD_REQUEST)
 
         # Check for validationerror

--- a/ninetofiver/tests.py
+++ b/ninetofiver/tests.py
@@ -6,8 +6,9 @@ from django.utils.timezone import utc
 from ninetofiver import factories
 from decimal import Decimal
 from datetime import timedelta
-import tempfile
+from django.core.exceptions import ValidationError
 
+import tempfile
 import datetime
 
 now = datetime.date.today()
@@ -791,7 +792,11 @@ class MyLeaveRequestsServiceAPITestcase(APITestCase):
         self.assertEqual(patch_response.status_code, status.HTTP_201_CREATED)
 
         # Check for update error
-        update_data['leave'] = 99999999
+        new_leave = factories.LeaveFactory.create(
+            user = user,
+            leave_type = factories.LeaveTypeFactory.create()
+        )
+        update_data['leave'] = new_leave.id
 
         patch_duplicate_date_response = self.client.patch(url, update_data, format='json')
         self.assertEqual(patch_duplicate_date_response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -809,6 +814,7 @@ class MyLeaveRequestsServiceAPITestcase(APITestCase):
         }
 
         post_invalid_date_response = self.client.post(url, invalid_data, format='json')
+        self.assertRaises(ValidationError)
         self.assertEqual(post_invalid_date_response.status_code, status.HTTP_400_BAD_REQUEST)
 
 

--- a/ninetofiver/urls.py
+++ b/ninetofiver/urls.py
@@ -52,6 +52,7 @@ router.register(r'my_performances/activity', views.MyActivityPerformanceViewSet,
 router.register(r'my_performances/standby', views.MyStandbyPerformanceViewSet, base_name='mystandbyperformance')
 router.register(r'my_performances', views.MyPerformanceViewSet, base_name='myperformance')
 router.register(r'my_attachments', views.MyAttachmentViewSet, base_name='myattachment')
+router.register(r'my_workschedules', views.MyWorkScheduleViewSet, base_name='myworkschedule')
 
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.

--- a/ninetofiver/views.py
+++ b/ninetofiver/views.py
@@ -490,7 +490,7 @@ class MyContractViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        return models.Contract.objects.filter(contractuser__user=user)
+        return models.Contract.objects.filter(contractuser__user=user).distinct()
 
 
 class MyContractDurationViewSet(viewsets.ReadOnlyModelViewSet):
@@ -503,7 +503,7 @@ class MyContractDurationViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        return models.Contract.objects.filter(contractuser__user=user)
+        return models.Contract.objects.filter(contractuser__user=user).distinct()
 
 
 class MyPerformanceViewSet(GenericHierarchicalReadOnlyViewSet):

--- a/ninetofiver/views.py
+++ b/ninetofiver/views.py
@@ -101,7 +101,7 @@ class EmploymentContractViewSet(viewsets.ModelViewSet):
 
 class WorkScheduleViewSet(viewsets.ModelViewSet):
     """
-    API endpoint that allows employment contracts to be viewed or edited.
+    API endpoint that allows workschedules to be viewed or edited.
     """
     queryset = models.WorkSchedule.objects.all()
     serializer_class = serializers.WorkScheduleSerializer
@@ -560,3 +560,16 @@ class MyAttachmentViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         user = self.request.user
         return user.attachment_set.all()
+
+
+class MyWorkScheduleViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows workschedules for the currently authenticated user to be viewed or edited.
+    """
+    serializer_class = serializers.MyWorkScheduleSerializer
+    filter_class = filters.WorkScheduleFilter
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def get_queryset(self):
+        user = self.request.user
+        return models.WorkSchedule.objects.filter(employmentcontract__user=user)

--- a/ninetofiver/views.py
+++ b/ninetofiver/views.py
@@ -331,7 +331,7 @@ class MyUserServiceAPIView(APIView):
         return Response(data)
 
 
-class MyLeaveRequestServiceAPIView(generics.ListCreateAPIView):
+class MyLeaveRequestServiceAPIView(generics.CreateAPIView):
     """
     Set the leavedates for the corresponding leave.
     """


### PR DESCRIPTION
I added my_workschedules to the API, as to get around messy and unnecessary calls for a small filter necessary for a call. This works more intuitively.

Fixed 2 things;
- MyContract API was returning duplicate results based on a foreign key, result was correct according to Djangologics, but it wasn't the desired result.
- When a call to MyLeaveRequestsService was made with a leave_end with time 00:00:00, it would crash because it could not differentiate between start && end. This is now fixed && gets checked explicitly.