### PR TITLE
configure OS variables before import wsgi app

### DIFF
--- a/ninetofiver/wsgi.py
+++ b/ninetofiver/wsgi.py
@@ -1,7 +1,7 @@
 import os
-from configurations.wsgi import get_wsgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ninetofiver.settings')
 os.environ.setdefault('DJANGO_CONFIGURATION', 'Dev')
 
+from configurations.wsgi import get_wsgi_application
 application = get_wsgi_application()


### PR DESCRIPTION
otherwise Apache throws this error:

```
[Tue May 02 15:36:48.131896 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148] mod_wsgi (pid=14285): Target WSGI script '/opt/ninetofiver/ninetofiver/wsgi.py' cannot be loaded as Python module.
[Tue May 02 15:36:48.131941 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148] mod_wsgi (pid=14285): Exception occurred processing WSGI script '/opt/ninetofiver/ninetofiver/wsgi.py'.
[Tue May 02 15:36:48.132031 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148] Traceback (most recent call last):
[Tue May 02 15:36:48.132059 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148]   File "/opt/ninetofiver/ninetofiver/wsgi.py", line 2, in <module>
[Tue May 02 15:36:48.132068 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148]     from configurations.wsgi import get_wsgi_application
[Tue May 02 15:36:48.132073 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148]   File "/opt/ninetofiver/env/lib/python3.5/site-packages/configurations/wsgi.py", line 3, in <module>
[Tue May 02 15:36:48.132076 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148]     importer.install()
[Tue May 02 15:36:48.132081 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148]   File "/opt/ninetofiver/env/lib/python3.5/site-packages/configurations/importer.py", line 49, in install
[Tue May 02 15:36:48.132083 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148]     importer = ConfigurationImporter(check_options=check_options)
[Tue May 02 15:36:48.132087 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148]   File "/opt/ninetofiver/env/lib/python3.5/site-packages/configurations/importer.py", line 68, in __init__
[Tue May 02 15:36:48.132089 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148]     self.validate()
[Tue May 02 15:36:48.132093 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148]   File "/opt/ninetofiver/env/lib/python3.5/site-packages/configurations/importer.py", line 104, in validate
[Tue May 02 15:36:48.132095 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148]     raise ImproperlyConfigured(self.error_msg.format(self.namevar))
[Tue May 02 15:36:48.132108 2017] [wsgi:error] [pid 11111] [remote 192.168.1.1:148] django.core.exceptions.ImproperlyConfigured: Configuration cannot be imported, environment variable DJANGO_CONFIGURATION is undefined.
```

Signed-off-by: Pavel Pulec <kayn@inuits.eu>