### PR TITLE
Updated tests

### DIFF
--- a/ninetofiver/filters.py
+++ b/ninetofiver/filters.py
@@ -266,17 +266,24 @@ class LeaveFilter(FilterSet):
         return queryset.filter(leavedate__starts_at__gte=base_date).distinct()
 
 
+    def leavedate_timesheet(self, queryset, name, value):
+        """Filters distinct leavedates linked to the provided timesheet."""
+
+        return queryset.filter(leavedate__timesheet=value).distinct()
+
+
     order_fields = ('status', 'description')
     order_by = NullLastOrderingFilter(fields=order_fields)
 
     leavedate__range = django_filters.CharFilter(method='leavedate_range_distinct')
     leavedate__gte = django_filters.CharFilter(method='leavedate_upcoming_distinct')
+    leavedate__timesheet = django_filters.NumberFilter(method='leavedate_timesheet')
 
     class Meta:
         model = models.Leave
         fields = {
             'status': ['exact'],
-            'description': ['exact', 'contains', 'icontains']
+            'description': ['exact', 'contains', 'icontains'],
         }
 
 
@@ -457,6 +464,7 @@ class PerformanceFilter(FilterSet):
         model = models.Performance
         fields = {
             'day': ['exact', 'gt', 'gte', 'lt', 'lte', ],
+            'timesheet': ['exact', ],
             'timesheet__month': ['exact', 'gte', 'lte', ],
             'timesheet__year': ['exact', 'gte', 'lte', ],
         }

--- a/ninetofiver/tests.py
+++ b/ninetofiver/tests.py
@@ -544,12 +544,12 @@ class ActivityPerformanceAPITestCase(testcases.ReadWriteRESTAPITestCaseMixin, te
     factory_class = factories.ActivityPerformanceFactory
     user_factory = factories.AdminFactory
     create_data = {
-        'day': 12,
+        'day': 9,
         'duration': 12,
         'description': 'Just doing things',
     }
     update_data = {
-        'day': 13,
+        'day': 10,
         'duration': 13,
         'description': 'Not doing all that much',
     }
@@ -584,10 +584,10 @@ class StandbyPerformanceAPITestCase(testcases.ReadWriteRESTAPITestCaseMixin, tes
     factory_class = factories.StandbyPerformanceFactory
     user_factory = factories.AdminFactory
     create_data = {
-        'day': 12,
+        'day': 9,
     }
     update_data = {
-        'day': 13,
+        'day': 10,
     }
 
     def setUp(self):


### PR DESCRIPTION
Standby- && MyStandbyPerformance now base themselves on different days.
Faker just generates a number from 1 to 27 for the day,
standbyperformances can't be linked when there already exists a timesheet - day pair with those values.